### PR TITLE
Fix looser throw specifier error

### DIFF
--- a/Source/buildimplementationcpp.go
+++ b/Source/buildimplementationcpp.go
@@ -221,7 +221,7 @@ func buildCPPInternalException (wHeader LanguageWriter, wImpl LanguageWriter, Na
 	wHeader.Writeln("  /**");
 	wHeader.Writeln("  * Returns error message");
 	wHeader.Writeln("  */");
-	wHeader.Writeln("  const char* what () const;");
+	wHeader.Writeln("  const char* what () const noexcept override;");
 	wHeader.Writeln("};");
 	wHeader.Writeln("");
 	
@@ -248,7 +248,7 @@ func buildCPPInternalException (wHeader LanguageWriter, wImpl LanguageWriter, Na
 	wImpl.Writeln("  return m_errorCode;");
 	wImpl.Writeln("}");
 	wImpl.Writeln("");
-	wImpl.Writeln("const char * E%sInterfaceException::what () const", NameSpace);
+	wImpl.Writeln("const char * E%sInterfaceException::what () const noexcept", NameSpace);
 	wImpl.Writeln("{");
 	wImpl.Writeln("  return m_errorMessage.c_str();");
 	wImpl.Writeln("}");


### PR DESCRIPTION
GCC reports a "looser throw specifier" error when attempting to compile the generated interface exception class. A noexcept specifier has been used in the generated binding for exceptions, but not in the interface class.

I haven't tested this change (as I'm not set up to build ACT), but I am only changing strings and I've checked the changed strings build on MSVC/GCC