### PR TITLE
Fix pascal impl&binding with struct returns

### DIFF
--- a/Source/buildbindingpascal.go
+++ b/Source/buildbindingpascal.go
@@ -895,7 +895,7 @@ func writePascalClassMethodImplementation (method ComponentDefinitionMethod, w L
 						resultCommands = append (resultCommands, fmt.Sprintf ("  Result := (Result%s <> 0);", param.ParamName));
 						
 					case "struct":
-						callFunctionParameters = callFunctionParameters + "@A" + param.ParamName;
+						callFunctionParameters = callFunctionParameters + "@Result";
 
 					case "basicarray", "structarray":
 						defineCommands = append (defineCommands, "  countNeeded" + param.ParamName + ": QWord;");

--- a/Source/languagepascal.go
+++ b/Source/languagepascal.go
@@ -529,7 +529,7 @@ func generatePlainPascalParameter(param ComponentDefinitionParam, className stri
 				cParams[0].ParamType = cParamTypeName;
 				cParams[0].ParamName = "p" + param.ParamName;
 				cParams[0].ParamComment = fmt.Sprintf("* @param[out] %s - %s", cParams[0].ParamName, param.ParamDescription);
-				cParams[0].ParamConvention = "out ";
+				cParams[0].ParamConvention = "";
 				cParams[0].ParamTypeNoConvention = "P" + cParamTypeName[1:];
 				
 			case "basicarray":


### PR DESCRIPTION
This fixes Issue #9 
Struct results should be assigned directly to the result (@Result)
Since structs are passed by pointers, there is no need for the 'out' keyword