### PR TITLE
Add const and noexcept specifiers

### DIFF
--- a/Source/buildbindingcdynamic.go
+++ b/Source/buildbindingcdynamic.go
@@ -685,7 +685,7 @@ func buildDynamicCppHeader(component ComponentDefinition, w LanguageWriter, Name
 	w.Writeln("  /**")
 	w.Writeln("  * Returns error code")
 	w.Writeln("  */")
-	w.Writeln("  %sResult getErrorCode ()", NameSpace)
+	w.Writeln("  %sResult getErrorCode () const noexcept", NameSpace)
 	w.Writeln("  {")
 	w.Writeln("    return m_errorCode;")
 	w.Writeln("  }")

--- a/Source/buildbindingcpp.go
+++ b/Source/buildbindingcpp.go
@@ -244,7 +244,7 @@ func buildCPPHeaderAndImplementation(component ComponentDefinition, w LanguageWr
 	cppimplw.Writeln("    m_errorCode = errorCode;")
 	cppimplw.Writeln("  }")
 	cppimplw.Writeln("")
-	cppimplw.Writeln("  %sResult E%sException::getErrorCode ()", NameSpace, NameSpace)
+	cppimplw.Writeln("  %sResult E%sException::getErrorCode () const noexcept", NameSpace, NameSpace)
 	cppimplw.Writeln("  {")
 	cppimplw.Writeln("    return m_errorCode;")
 	cppimplw.Writeln("  }")


### PR DESCRIPTION
 - The function to query the error code from an exception should be
const noexcept.

 - I do not have a go environment set up, so I have not tested this, but I have made the corresponding changes in my generated code.
