### PR TITLE
Added Language String support for C++ implementation (Issue #83)

### DIFF
--- a/Source/buildimplementationcpp.go
+++ b/Source/buildimplementationcpp.go
@@ -244,7 +244,7 @@ func buildCPPInternalException(wHeader LanguageWriter, wImpl LanguageWriter, Nam
 	wImpl.Writeln(" Class E%sInterfaceException", NameSpace);
 	wImpl.Writeln("**************************************************************************************************************************/");
 	wImpl.Writeln("E%sInterfaceException::E%sInterfaceException(%sResult errorCode)", NameSpace, NameSpace, NameSpace);
-	wImpl.Writeln("  : m_errorMessage(\"%s Error \" + std::to_string (errorCode))", NameSpace);
+	wImpl.Writeln("  : m_errorMessage(%s_GETERRORSTRING (errorCode))",  strings.ToUpper (NameSpace));
 	wImpl.Writeln("{");
 	wImpl.Writeln("  m_errorCode = errorCode;");
 	wImpl.Writeln("}");

--- a/Source/languagec.go
+++ b/Source/languagec.go
@@ -144,6 +144,22 @@ func buildSharedCCPPTypesHeader(component ComponentDefinition, w LanguageWriter,
 	}
 
 	w.Writeln("");
+
+	w.Writeln("/*************************************************************************************************************************");
+	w.Writeln(" Error strings for %s", NameSpace);
+	w.Writeln("**************************************************************************************************************************/");
+	w.Writeln("");
+	w.Writeln("inline const char * %s_GETERRORSTRING (%sResult nErrorCode) {", strings.ToUpper (NameSpace), NameSpace);
+	w.Writeln("  switch (nErrorCode) {");
+	w.Writeln("    case %s_SUCCESS: return \"no error\";", strings.ToUpper (NameSpace));
+	for i := 0; i < len(component.Errors.Errors); i++ {
+		errorcode := component.Errors.Errors[i];
+		w.Writeln("    case %s_ERROR_%s: return \"%s\";", strings.ToUpper (NameSpace), errorcode.Name, errorcode.Description);
+	}
+	w.Writeln("    default: return \"unknown error\";");
+	w.Writeln("  }");
+	w.Writeln("}");
+	w.Writeln("");
 	
 	w.Writeln("/*************************************************************************************************************************");
 	w.Writeln(" Declaration of handle classes ");


### PR DESCRIPTION
A new inline function in the types header can translate an error code into a user readable string.