### PR TITLE
Fix visual studio 16.6 warning in the cpp bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,3 @@ debug
 *_component
 
 Examples/*.xml
-*.txt
-*.py
-ACT.code-workspace
-test/AbstractCAM.xml
-test/dcamcomponents.xml

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ debug
 *_component
 
 Examples/*.xml
+*.txt
+*.py
+ACT.code-workspace
+test/AbstractCAM.xml
+test/dcamcomponents.xml

--- a/Source/buildbindingccpp.go
+++ b/Source/buildbindingccpp.go
@@ -246,7 +246,7 @@ func buildDynamicCCPPHeader(component ComponentDefinition, w LanguageWriter, Nam
 	w.Writeln(" Function Table Structure")
 	w.Writeln("**************************************************************************************************************************/")
 	w.Writeln("")
-	w.Writeln("typedef struct {")
+	w.Writeln("typedef struct s%sDynamicWrapperTableStruct {", NameSpace)
 	w.Writeln("  void * m_LibraryHandle;")
 
 	for i := 0; i < len(component.Classes); i++ {
@@ -267,22 +267,24 @@ func buildDynamicCCPPHeader(component ComponentDefinition, w LanguageWriter, Nam
 
 	for i := 0; i < len(component.Classes); i++ {
 		class := component.Classes[i]
+		structName := fmt.Sprintf("s%sFunctionTable%sStruct", NameSpace, class.ClassName)
+		typedefName := fmt.Sprintf("s%sFunctionTable%s", NameSpace, class.ClassName)
 		if len(class.ParentClass) > 0 {
 			paramNameSpace, paramClassName, _ := decomposeParamClassName(class.ParentClass)
 			if len(paramNameSpace) == 0 {
-				w.Writeln("typedef struct : s%sFunctionTable%s {", NameSpace, class.ParentClass)
+				w.Writeln("typedef struct %s : s%sFunctionTable%s {", structName, NameSpace, class.ParentClass)
 			} else {
-				w.Writeln("typedef struct : s%sFunctionTable%s {", component.ImportedComponentDefinitions[paramNameSpace].NameSpace, paramClassName)
+				w.Writeln("typedef struct %s : s%sFunctionTable%s {", structName, component.ImportedComponentDefinitions[paramNameSpace].NameSpace, paramClassName)
 			}
 		} else {
-			w.Writeln("typedef struct {")
+			w.Writeln("typedef struct %s {", structName)
 		}
 
 		for j := 0; j < len(class.Methods); j++ {
 			method := class.Methods[j]
 			w.Writeln("  P%s%s_%sPtr m_%s_%s;", NameSpace, class.ClassName, method.MethodName, class.ClassName, method.MethodName)
 		}
-		w.Writeln("} s%sFunctionTable%s;", NameSpace, class.ClassName)
+		w.Writeln("} %s;", typedefName)
 		w.Writeln("")
 	}
 


### PR DESCRIPTION
## Issues - #99 

## Symptom

When compiling the c++ act bindings for a cross component interface project the visual studio compiler outputs warningsof the form:

```
typedef struct {
  PAbstractCAMBase_GetLastErrorPtr m_Base_GetLastError;
  PAbstractCAMBase_ReleaseInstancePtr m_Base_ReleaseInstance;
  PAbstractCAMBase_AcquireInstancePtr m_Base_AcquireInstance;
  PAbstractCAMBase_GetVersionPtr m_Base_GetVersion;
  PAbstractCAMBase_GetSymbolLookupMethodPtr m_Base_GetSymbolLookupMethod;
} sAbstractCAMFunctionTableBase;
typedef struct : sAbstractCAMFunctionTableBase {
  PAbstractCAMLinking_CreateLinkerPtr m_Linking_CreateLinker;
  PAbstractCAMLinking_QueryStrategyPtr m_Linking_QueryStrategy;
} sAbstractCAMFunctionTableLinking;
```

## Problem

This appars to be the issue in https://developercommunity.visualstudio.com/content/problem/1034754/warning-c5208-a-c20-feature-occurs-when-compiling-1.html

In particular we define anonymous structs with member that are then typedefed

## Solution

We give a name to the function table structs based on the typedef name with "Struct" appended to make it unique.

## Verification

Recompiled bindings after the change with no warning. Tests to call the interface still pass.