### PR TITLE
 Out optionalclass is not generating valid code in C++ implementation. #101 

### DIFF
--- a/Source/buildimplementationcpp.go
+++ b/Source/buildimplementationcpp.go
@@ -1533,7 +1533,7 @@ func generatePrePostCallCPPFunctionCode(component ComponentDefinition, method Co
 					postCallCode = append(postCallCode, fmt.Sprintf("*%s = %s->GetHandle();", variableName, outVarName));
 					callParameters = callParameters + outVarName
 				} else {
-					preCallCode = append(preCallCode, fmt.Sprintf("%s* pBase%s(nullptr);", IBaseClassName, param.ParamName))
+					preCallCode = append(preCallCode, fmt.Sprintf("I%s* pBase%s(nullptr);", paramClassName, param.ParamName))
 					postCallCode = append(postCallCode, fmt.Sprintf("*%s = (%s*)(pBase%s);", variableName, IBaseClassName, param.ParamName));
 					callParameters = callParameters + "pBase" + param.ParamName
 				}


### PR DESCRIPTION
If there is an out optionalclass value, the code generator creates a base result variable:
IBase * pBaseHandlerInstance(nullptr);

This leads to a compile error of the implementation. The class should be the correct output class, like
ISignalHandler * pBaseHandlerInstance(nullptr);