### PR TITLE
Better error messages (CrossComponentInheritance)

### DIFF
--- a/Source/buildbindingccpp.go
+++ b/Source/buildbindingccpp.go
@@ -1299,21 +1299,23 @@ func buildCppHeader(component ComponentDefinition, w LanguageWriter, NameSpace s
 	w.Writeln("  const char* getErrorName() const noexcept")
 	w.Writeln("  {")
 	w.Writeln("    switch(getErrorCode()) {")
+	w.Writeln("      case %s_SUCCESS: return \"SUCCESS\";", strings.ToUpper(NameSpace))
 	for _, errorDef := range(component.Errors.Errors) {
 		w.Writeln("      case %s_ERROR_%s: return \"%s\";", strings.ToUpper(NameSpace), errorDef.Name, errorDef.Name)
 	}
 	w.Writeln("    }")
-	w.Writeln("    return \"\"");
+	w.Writeln("    return \"UNKNOWN\";");
 	w.Writeln("  }")
 	w.Writeln("")
 	w.Writeln("  const char* getErrorDescription() const noexcept")
 	w.Writeln("  {")
 	w.Writeln("    switch(getErrorCode()) {")
+	w.Writeln("      case %s_SUCCESS: return \"success\";", strings.ToUpper(NameSpace))
 	for _, errorDef := range(component.Errors.Errors) {
 		w.Writeln("      case %s_ERROR_%s: return \"%s\";", strings.ToUpper(NameSpace), errorDef.Name, errorDef.Description)
 	}
 	w.Writeln("    }")
-	w.Writeln("    return \"\"");
+	w.Writeln("    return \"unknown error\";");
 	w.Writeln("  }")
 	w.Writeln("")
 

--- a/Source/buildbindingccpp.go
+++ b/Source/buildbindingccpp.go
@@ -1263,15 +1263,16 @@ func buildCppHeader(component ComponentDefinition, w LanguageWriter, NameSpace s
 	w.Writeln("  * Error message for the Exception.")
 	w.Writeln("  */")
 	w.Writeln("  std::string m_errorMessage;")
+	w.Writeln("  std::string m_originalErrorMessage;")
 	w.Writeln("")
 	w.Writeln("public:")
 	w.Writeln("  /**")
 	w.Writeln("  * Exception Constructor.")
 	w.Writeln("  */")
 	w.Writeln("  E%sException(%sResult errorCode, const std::string & sErrorMessage)", NameSpace, NameSpace)
-	w.Writeln("    : m_errorMessage(\"%s Error \" + std::to_string(errorCode) + \" (\" + sErrorMessage + \")\")", NameSpace)
+	w.Writeln("    : m_originalErrorMessage(sErrorMessage), m_errorCode(errorCode)")
 	w.Writeln("  {")
-	w.Writeln("    m_errorCode = errorCode;")
+	w.Writeln("    m_errorMessage = buildErrorMessage();")
 	w.Writeln("  }")
 	w.Writeln("")
 	w.Writeln("  /**")
@@ -1289,7 +1290,44 @@ func buildCppHeader(component ComponentDefinition, w LanguageWriter, NameSpace s
 	w.Writeln("  {")
 	w.Writeln("    return m_errorMessage.c_str();")
 	w.Writeln("  }")
+	w.Writeln("");
+	w.Writeln("  const char* getErrorMessage() const noexcept")
+	w.Writeln("  {")
+	w.Writeln("    return m_originalErrorMessage.c_str();")
+	w.Writeln("  }")
 	w.Writeln("")
+	w.Writeln("  const char* getErrorName() const noexcept")
+	w.Writeln("  {")
+	w.Writeln("    switch(getErrorCode()) {")
+	for _, errorDef := range(component.Errors.Errors) {
+		w.Writeln("      case %s_ERROR_%s: return \"%s\";", strings.ToUpper(NameSpace), errorDef.Name, errorDef.Name)
+	}
+	w.Writeln("    }")
+	w.Writeln("    return \"\"");
+	w.Writeln("  }")
+	w.Writeln("")
+	w.Writeln("  const char* getErrorDescription() const noexcept")
+	w.Writeln("  {")
+	w.Writeln("    switch(getErrorCode()) {")
+	for _, errorDef := range(component.Errors.Errors) {
+		w.Writeln("      case %s_ERROR_%s: return \"%s\";", strings.ToUpper(NameSpace), errorDef.Name, errorDef.Description)
+	}
+	w.Writeln("    }")
+	w.Writeln("    return \"\"");
+	w.Writeln("  }")
+	w.Writeln("")
+
+	w.Writeln("private:")
+	w.Writeln("")
+
+	w.Writeln("  std::string buildErrorMessage() const noexcept")
+	w.Writeln("  {")
+	w.Writeln("    std::string msg = m_originalErrorMessage;")
+	w.Writeln("    if (msg.empty()) {")
+	w.Writeln("      msg = getErrorDescription();")
+	w.Writeln("    }")
+	w.Writeln("    return std::string(\"Error: \") + getErrorName() + \": \" + msg;")
+	w.Writeln("  }")
 
 	w.Writeln("};")
 


### PR DESCRIPTION
ACT-generated bindings don't contain a mapping between error codes and human-readable names and descriptions. If exception text gets printed this can result in very unfriendly error messages for developers and (if a crash escapes into the wild) users.

This PR adds methods to the binding exception class to get the more human-friendly error name and description specified in the IDL file. The `what()` method is reworked to give a default error text with the error name and description, not the number code.