### PR TITLE
Better error messages (develop)

### DIFF
--- a/Source/buildbindingccpp.go
+++ b/Source/buildbindingccpp.go
@@ -1220,21 +1220,23 @@ func buildCppHeader(component ComponentDefinition, w LanguageWriter, NameSpace s
 	w.Writeln("  const char* getErrorName() const noexcept")
 	w.Writeln("  {")
 	w.Writeln("    switch(getErrorCode()) {")
+	w.Writeln("      case %s_SUCCESS: return \"SUCCESS\";", strings.ToUpper(NameSpace))
 	for _, errorDef := range(component.Errors.Errors) {
 		w.Writeln("      case %s_ERROR_%s: return \"%s\";", strings.ToUpper(NameSpace), errorDef.Name, errorDef.Name)
 	}
 	w.Writeln("    }")
-	w.Writeln("    return \"\"");
+	w.Writeln("    return \"UNKNOWN\";");
 	w.Writeln("  }")
 	w.Writeln("")
 	w.Writeln("  const char* getErrorDescription() const noexcept")
 	w.Writeln("  {")
 	w.Writeln("    switch(getErrorCode()) {")
+	w.Writeln("      case %s_SUCCESS: return \"success\";", strings.ToUpper(NameSpace))
 	for _, errorDef := range(component.Errors.Errors) {
 		w.Writeln("      case %s_ERROR_%s: return \"%s\";", strings.ToUpper(NameSpace), errorDef.Name, errorDef.Description)
 	}
 	w.Writeln("    }")
-	w.Writeln("    return \"\"");
+	w.Writeln("    return \"unknown error\";");
 	w.Writeln("  }")
 	w.Writeln("")
 


### PR DESCRIPTION
ACT-generated bindings don't contain a mapping between error codes and human-readable names and descriptions. If exception text gets printed this can result in very unfriendly error messages for developers and (if a crash escapes into the wild) users.

This PR adds methods to the binding exception class to get the more human-friendly error name and description specified in the IDL file. The `what()` method is reworked to give a default error text with the error name and description, not the number code.