### PR TITLE
Fix initialisation order warning

### DIFF
--- a/Source/buildbindingccpp.go
+++ b/Source/buildbindingccpp.go
@@ -1191,7 +1191,7 @@ func buildCppHeader(component ComponentDefinition, w LanguageWriter, NameSpace s
 	w.Writeln("  * Exception Constructor.")
 	w.Writeln("  */")
 	w.Writeln("  E%sException(%sResult errorCode, const std::string & sErrorMessage)", NameSpace, NameSpace)
-	w.Writeln("    : m_originalErrorMessage(sErrorMessage), m_errorCode(errorCode)")
+	w.Writeln("    : m_errorCode(errorCode), m_originalErrorMessage(sErrorMessage)")
 	w.Writeln("  {")
 	w.Writeln("    m_errorMessage = buildErrorMessage();")
 	w.Writeln("  }")


### PR DESCRIPTION
PR is done on behalf of @woodwan by cherry picking from https://github.com/Autodesk/AutomaticComponentToolkit/pull/153
```
My recent change to improve error messages introduced a warning into the generated binding because the initializer list for the exception constructor is not in the order in which members are declared. This PR should fix it.
```
