### PR TITLE
Fix MacOS build script

### DIFF
--- a/Build/build.sh
+++ b/Build/build.sh
@@ -10,24 +10,24 @@ basepath="$(cd "$(dirname "$0")" && pwd)"
 cd "$basepath/../Source"
 
 Sources="actutils.go automaticcomponenttoolkit.go buildbindingccpp.go buildbindingcsharp.go buildbindinggo.go buildbindingnode.go buildbindingpascal.go buildbindingpython.go buildbindingjava.go buildimplementationcpp.go buildimplementationpascal.go componentdefinition.go componentdiff.go languagewriter.go languagec.go languagecpp.go languagepascal.go"
-GOARCH="amd64"
+export GOARCH="amd64"
 
 echo "Build act.exe"
-GOOS="windows"
+export GOOS="windows"
 go build -o ../act.exe $Sources || failed "Error compiling act.exe"
 
 echo "Build act.linux"
-GOOS="linux"
+export GOOS="linux"
 go build -o ../act.linux $Sources || failed "Error compiling act.linux"
 
 echo "Build act.darwin"
-GOOS="darwin"
+export GOOS="darwin"
 go build -o ../act.darwin $Sources || failed "Error compiling act.darwin"
 
 echo "Build act.arm.linux" || failed "Error compiling act.arm.linux"
-GOOS="linux"
-GOARCH="arm"
-GOARM="5"
+export GOOS="linux"
+export GOARCH="arm"
+export GOARM="5"
 go build -o ../act.arm.linux $Sources
 
 cd "$startingpath"


### PR DESCRIPTION
Make GOARCH, GOOS and GOARM environment visible to `go` compiler