### PR TITLE
Do null check for C# pointer to avoid crash.

### DIFF
--- a/Source/buildbindingcsharp.go
+++ b/Source/buildbindingcsharp.go
@@ -407,7 +407,10 @@ func writeCSharpClassMethodImplementation(method ComponentDefinitionMethod, w La
 				if (ParamTypeName == "IntPtr") {
 					callFunctionParameter = "A" + param.ParamName
 				} else {
-					callFunctionParameter = "A" + param.ParamName + ".GetHandle()"
+					defineCommands = append(defineCommands, fmt.Sprintf("  IntPtr A%sHandle = IntPtr.Zero;", param.ParamName))
+					defineCommands = append(defineCommands, fmt.Sprintf("  if (A%s != null)", param.ParamName))
+					defineCommands = append(defineCommands, fmt.Sprintf("    A%sHandle = A%s.GetHandle();", param.ParamName, param.ParamName))
+					callFunctionParameter = "A" + param.ParamName + "Handle"
 				}
 				
 				initCallParameter = callFunctionParameter


### PR DESCRIPTION
@martinweismann PTAL.

Example for the generated binding code.
![image](https://user-images.githubusercontent.com/6661782/141883302-3e6b1632-53a3-457f-ba98-0aceaeadd9d7.png)
