### PR TITLE
Don't require C++17 for ClientImpl base classes

### DIFF
--- a/Source/buildimplementationcpp.go
+++ b/Source/buildimplementationcpp.go
@@ -1786,6 +1786,7 @@ func generatePrePostCallCPPFunctionCode(component ComponentDefinition, method Co
 	for k := 0; k < len(method.Params); k++ {
 		param := method.Params[k]
 		variableName := getCppVariableName(param)
+		cppParamType := getCppParamType(param, NameSpace, true)
 
 		switch param.ParamPass {
 		case "in":
@@ -1806,7 +1807,8 @@ func generatePrePostCallCPPFunctionCode(component ComponentDefinition, method Co
 				checkInputCode = append(checkInputCode, fmt.Sprintf("  throw %s (%s_ERROR_INVALIDPARAM);", exceptionType, strings.ToUpper(NameSpace)))
 				callParameters = callParameters + fmt.Sprintf("n%sBufferSize, ", param.ParamName) + variableName
 				if (isClientImpl) {
-					callParameters = callParameters + fmt.Sprintf("%sInputVector(%s, n%sBufferSize)", ClassIdentifier, variableName, param.ParamName) 
+          inputVecTypeParam := cppParamType[:len(cppParamType)-2]
+					callParameters = callParameters + fmt.Sprintf("%sInputVector<%s>(%s, n%sBufferSize)", ClassIdentifier, inputVecTypeParam, variableName, param.ParamName) 
 				} else {
 					callParameters = callParameters + fmt.Sprintf("n%sBufferSize, ", param.ParamName) + variableName
 				}
@@ -1814,7 +1816,8 @@ func generatePrePostCallCPPFunctionCode(component ComponentDefinition, method Co
 				checkInputCode = append(checkInputCode, fmt.Sprintf("if ( (!p%sBuffer) && (n%sBufferSize>0))", param.ParamName, param.ParamName))
 				checkInputCode = append(checkInputCode, fmt.Sprintf("  throw %s (%s_ERROR_INVALIDPARAM);", exceptionType, strings.ToUpper(NameSpace)))
 				if (isClientImpl) {
-					callParameters = callParameters + fmt.Sprintf("%sInputVector(%s, n%sBufferSize)", ClassIdentifier, variableName, param.ParamName) 
+          inputVecTypeParam := cppParamType[:len(cppParamType)-2]
+					callParameters = callParameters + fmt.Sprintf("%sInputVector<%s>(%s, n%sBufferSize)", ClassIdentifier, inputVecTypeParam, variableName, param.ParamName) 
 				} else {
 					callParameters = callParameters + fmt.Sprintf("n%sBufferSize, ", param.ParamName) + variableName
 				}


### PR DESCRIPTION
## Symptom
Compilation failures when compiling against binding with C++14.

## Problem
Generated ClientImpl code relies on template type deduction for constructors, which was added in C++17.

## Solution
Make the type explicit.