### PR TITLE
Fix 'out' arguments for javascript bindings

### DIFF
--- a/Build/build.sh
+++ b/Build/build.sh
@@ -6,7 +6,7 @@ startingpath="$(pwd)"
 basepath="$(cd "$(dirname "$0")" && pwd)"
 cd "$basepath/../Source"
 
-Sources="actutils.go automaticcomponenttoolkit.go buildbindingccpp.go buildbindingccppdocumentation.go buildbindingcsharp.go buildbindinggo.go buildbindingnode.go buildbindingpascal.go buildbindingpython.go buildbindingjava.go buildimplementationcpp.go buildimplementationpascal.go componentdefinition.go componentdiff.go languagewriter.go languagec.go languagecpp.go languagepascal.go"
+Sources="actutils.go automaticcomponenttoolkit.go buildbindingccpp.go buildbindingccppdocumentation.go buildbindingcsharp.go buildbindinggo.go buildbindingnode.go buildbindingpascal.go buildbindingpython.go buildbindingjava.go buildimplementationcpp.go buildimplementationpascal.go componentdefinition.go componentdiff.go languagewriter.go languagec.go languagecpp.go languagepascal.go  buildimplementationjs.go"
 
 echo "Build act.win64.exe"
 export GOARCH="amd64"

--- a/Source/buildimplementationcpp.go
+++ b/Source/buildimplementationcpp.go
@@ -913,7 +913,7 @@ func buildOutCacheTemplateParameters (method ComponentDefinitionMethod, NameSpac
 		
 			cppParamType := getCppParamType(param, NameSpace, true);
 			if param.ParamType == "class" || param.ParamType == "optionalclass" {
-				cppParamType = fmt.Sprintf("I%s%s*", ClassIdentifier, BaseClassName)
+				cppParamType = fmt.Sprintf("I%s%s*", ClassIdentifier, param.ParamClass)
 			}
 			result += cppParamType;
 		}
@@ -1006,7 +1006,7 @@ func writeCImplementationMethod(component ComponentDefinition, method ComponentD
 				return errors.New ("String out parameter without being the string out base class: " + method.MethodName)	
 			}
 		
-			templateParameters, err := buildOutCacheTemplateParameters (method, NameSpace, BaseClassName + "/*here*/", ClassIdentifier);
+			templateParameters, err := buildOutCacheTemplateParameters (method, NameSpace, BaseClassName, ClassIdentifier);
 			if err != nil {
 				return err
 			}
@@ -1725,7 +1725,7 @@ func generatePrePostCallCPPFunctionCode(component ComponentDefinition, method Co
 			case "class", "optionalclass":
 				checkInputCode = append(checkInputCode, fmt.Sprintf("if (p%s == nullptr)", param.ParamName))
 				checkInputCode = append(checkInputCode, fmt.Sprintf("  throw E%sInterfaceException (%s_ERROR_INVALIDPARAM);", NameSpace, strings.ToUpper(NameSpace)))
-
+	
 				paramNameSpace, paramClassName, _ := decomposeParamClassName(param.ParamClass)
 				if len(paramNameSpace) > 0 {
 					outVarName := fmt.Sprintf("p%s%s", paramNameSpace, param.ParamName)
@@ -1737,10 +1737,10 @@ func generatePrePostCallCPPFunctionCode(component ComponentDefinition, method Co
 					callParameters = callParameters + outVarName
 					outCallParameters = outCallParameters + outVarName
 				} else {
-					preCallCode = append(preCallCode, fmt.Sprintf("I%s* pBase%s(nullptr);", paramClassName, param.ParamName))
-					postCallCode = append(postCallCode, fmt.Sprintf("*%s = (%s*)(pBase%s);", variableName, IBaseClassName, param.ParamName));
-					callParameters = callParameters + "pBase" + param.ParamName
-					outCallParameters = outCallParameters + "(IBase*&)pBase" + param.ParamName
+					preCallCode = append(preCallCode, fmt.Sprintf("I%s* pClass%s(nullptr);", paramClassName, param.ParamName))
+					postCallCode = append(postCallCode, fmt.Sprintf("*%s = (%s*)(pClass%s);", variableName, IBaseClassName, param.ParamName));
+					callParameters = callParameters + "pClass" + param.ParamName
+					outCallParameters = fmt.Sprintf("%s pClass%s", outCallParameters, param.ParamName)
 				}
 				
 

--- a/Source/buildimplementationcpp.go
+++ b/Source/buildimplementationcpp.go
@@ -970,7 +970,9 @@ func writeCImplementationMethod(component ComponentDefinition, method ComponentD
 			theNameSpace := subComponent.NameSpace
 			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("if (s%s == \"%s\") {", method.Params[0].ParamName, theNameSpace))
 			wrapperName := "C" + ClassIdentifier + "Wrapper"
-			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("  %s::sP%sWrapper = %s::CWrapper::loadLibraryFromSymbolLookupMethod(p%s);", wrapperName, theNameSpace, theNameSpace, method.Params[1].ParamName))
+			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("  if (%s::sP%sWrapper.get() == nullptr) {", wrapperName, theNameSpace))
+			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("    %s::sP%sWrapper = %s::CWrapper::loadLibraryFromSymbolLookupMethod(p%s);", wrapperName, theNameSpace, theNameSpace, method.Params[1].ParamName))
+			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("  }"))
 			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("  bNameSpaceFound = true;"))
 			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("}"))
 		}

--- a/Source/buildimplementationcpp.go
+++ b/Source/buildimplementationcpp.go
@@ -973,6 +973,7 @@ func writeCImplementationMethod(component ComponentDefinition, method ComponentD
 			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("  if (%s::sP%sWrapper.get() != nullptr) {", wrapperName, theNameSpace))
 			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("    throw E%sInterfaceException(%s_ERROR_COULDNOTLOADLIBRARY);", NameSpace, strings.ToUpper(NameSpace)) )
 			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("  }"))
+			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("  %s::sP%sWrapper = %s::CWrapper::loadLibraryFromSymbolLookupMethod(p%s);", wrapperName, theNameSpace, theNameSpace, method.Params[1].ParamName))
 			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("  bNameSpaceFound = true;"))
 			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("}"))
 		}

--- a/Source/buildimplementationcpp.go
+++ b/Source/buildimplementationcpp.go
@@ -1006,7 +1006,7 @@ func writeCImplementationMethod(component ComponentDefinition, method ComponentD
 				return errors.New ("String out parameter without being the string out base class: " + method.MethodName)	
 			}
 		
-			templateParameters, err := buildOutCacheTemplateParameters (method, NameSpace, BaseClassName, ClassIdentifier);
+			templateParameters, err := buildOutCacheTemplateParameters (method, NameSpace, BaseClassName + "/*here*/", ClassIdentifier);
 			if err != nil {
 				return err
 			}

--- a/Source/buildimplementationcpp.go
+++ b/Source/buildimplementationcpp.go
@@ -970,8 +970,8 @@ func writeCImplementationMethod(component ComponentDefinition, method ComponentD
 			theNameSpace := subComponent.NameSpace
 			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("if (s%s == \"%s\") {", method.Params[0].ParamName, theNameSpace))
 			wrapperName := "C" + ClassIdentifier + "Wrapper"
-			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("  if (%s::sP%sWrapper.get() == nullptr) {", wrapperName, theNameSpace))
-			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("    %s::sP%sWrapper = %s::CWrapper::loadLibraryFromSymbolLookupMethod(p%s);", wrapperName, theNameSpace, theNameSpace, method.Params[1].ParamName))
+			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("  if (%s::sP%sWrapper.get() != nullptr) {", wrapperName, theNameSpace))
+			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("    throw E%sInterfaceException(%s_ERROR_COULDNOTLOADLIBRARY);", NameSpace, strings.ToUpper(NameSpace)) )
 			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("  }"))
 			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("  bNameSpaceFound = true;"))
 			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("}"))

--- a/Source/buildimplementationcpp.go
+++ b/Source/buildimplementationcpp.go
@@ -196,6 +196,7 @@ func buildCPPInternalException(wHeader LanguageWriter, wImpl LanguageWriter, Nam
 	wHeader.Writeln("#define __%s_INTERFACEEXCEPTION_HEADER", strings.ToUpper(NameSpace));
 	wHeader.Writeln("");
 
+	wHeader.Writeln("#include <string>");
 	wHeader.Writeln("#include <exception>");
 	wHeader.Writeln("#include <stdexcept>");
 
@@ -969,9 +970,6 @@ func writeCImplementationMethod(component ComponentDefinition, method ComponentD
 			theNameSpace := subComponent.NameSpace
 			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("if (s%s == \"%s\") {", method.Params[0].ParamName, theNameSpace))
 			wrapperName := "C" + ClassIdentifier + "Wrapper"
-			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("  if (%s::sP%sWrapper.get() != nullptr) {", wrapperName, theNameSpace))
-			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("    throw E%sInterfaceException(%s_ERROR_COULDNOTLOADLIBRARY);", NameSpace, strings.ToUpper(NameSpace)) )
-			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("  }"))
 			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("  %s::sP%sWrapper = %s::CWrapper::loadLibraryFromSymbolLookupMethod(p%s);", wrapperName, theNameSpace, theNameSpace, method.Params[1].ParamName))
 			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("  bNameSpaceFound = true;"))
 			callCPPFunctionCode = append(callCPPFunctionCode, fmt.Sprintf("}"))
@@ -1742,7 +1740,7 @@ func generatePrePostCallCPPFunctionCode(component ComponentDefinition, method Co
 					preCallCode = append(preCallCode, fmt.Sprintf("I%s* pBase%s(nullptr);", paramClassName, param.ParamName))
 					postCallCode = append(postCallCode, fmt.Sprintf("*%s = (%s*)(pBase%s);", variableName, IBaseClassName, param.ParamName));
 					callParameters = callParameters + "pBase" + param.ParamName
-					outCallParameters = outCallParameters + "pBase" + param.ParamName
+					outCallParameters = outCallParameters + "(IBase*&)pBase" + param.ParamName
 				}
 				
 

--- a/Source/buildimplementationjs.go
+++ b/Source/buildimplementationjs.go
@@ -252,7 +252,7 @@ func buildJSTypesFiles(component ComponentDefinition, NameSpace string, NameSpac
 		classdefinitionw.Writeln("namespace v8%s {", NameSpace );
 		classdefinitionw.Writeln("  namespace %s {", NameSpaceImplementation );
 		classdefinitionw.Writeln("")
-		classdefinitionw.Writeln("    _inline void registerInjectionClasses (std::shared_ptr<Cv8objectCreator> pObjectCreator, v8::Local<v8::Object> pTarget)", )
+		classdefinitionw.Writeln("    inline void registerInjectionClasses (std::shared_ptr<Cv8objectCreator> pObjectCreator, v8::Local<v8::Object> pTarget)", )
 		classdefinitionw.Writeln("    {")
 		for _, subComponent := range(component.ImportedComponentDefinitions) {
 		

--- a/Source/componentdefinition.go
+++ b/Source/componentdefinition.go
@@ -439,7 +439,7 @@ func checkOptions(options[] ComponentDefinitionEnumOption) (error) {
 
 	for j := 0; j < len(options); j++ {
 		option := options[j]
-		if !nameIsValidIdentifier(option.Name) {
+		if !nameIsValidEnumOptionIdentifier(option.Name) {
 			return fmt.Errorf("invalid option name \"%s\"", option.Name)
 		}
 		if (math.Abs( float64(option.Value)) > math.Exp2(31) - 1) {
@@ -780,6 +780,14 @@ func decomposeParamClassName(paramClassName string) (string, string, error) {
 	return namespace, className, nil
 }
 
+func nameIsValidEnumOptionIdentifier(name string) bool {
+	var IsValidIdentifier = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_]{0,63}$").MatchString
+	if (name != "") {
+		return IsValidIdentifier(name);
+	}
+	return false;
+}
+
 func nameIsValidIdentifier(name string) bool {
 	var IsValidIdentifier = regexp.MustCompile("^[A-Z][a-zA-Z0-9_]{0,63}$").MatchString
 	if (name != "") {
@@ -789,7 +797,7 @@ func nameIsValidIdentifier(name string) bool {
 }
 
 func descriptionIsValid(description string) bool {
-	var IsValidMethodDescription = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_\\\\/+\\-:,.=!?()'; |]*$").MatchString
+	var IsValidMethodDescription = regexp.MustCompile("^ *[a-zA-Z][a-zA-Z0-9_\\\\/+\\-:,.=!?()'; |]*$").MatchString
 	if (description != "") {
 		return IsValidMethodDescription(description);
 	}

--- a/Source/componentdefinition.go
+++ b/Source/componentdefinition.go
@@ -439,7 +439,7 @@ func checkOptions(options[] ComponentDefinitionEnumOption) (error) {
 
 	for j := 0; j < len(options); j++ {
 		option := options[j]
-		if !nameIsValidEnumOptionIdentifier(option.Name) {
+		if !nameIsValidIdentifier(option.Name) {
 			return fmt.Errorf("invalid option name \"%s\"", option.Name)
 		}
 		if (math.Abs( float64(option.Value)) > math.Exp2(31) - 1) {
@@ -780,14 +780,6 @@ func decomposeParamClassName(paramClassName string) (string, string, error) {
 	return namespace, className, nil
 }
 
-func nameIsValidEnumOptionIdentifier(name string) bool {
-	var IsValidIdentifier = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_]{0,63}$").MatchString
-	if (name != "") {
-		return IsValidIdentifier(name);
-	}
-	return false;
-}
-
 func nameIsValidIdentifier(name string) bool {
 	var IsValidIdentifier = regexp.MustCompile("^[A-Z][a-zA-Z0-9_]{0,63}$").MatchString
 	if (name != "") {
@@ -797,7 +789,7 @@ func nameIsValidIdentifier(name string) bool {
 }
 
 func descriptionIsValid(description string) bool {
-	var IsValidMethodDescription = regexp.MustCompile("^ *[a-zA-Z][a-zA-Z0-9_\\\\/+\\-:,.=!?()'; |]*$").MatchString
+	var IsValidMethodDescription = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_\\\\/+\\-:,.=!?()'; |]*$").MatchString
 	if (description != "") {
 		return IsValidMethodDescription(description);
 	}


### PR DESCRIPTION
Return out aguments from javascript methods as an array.
For example, where x and y are out arguments.

`const [x, y] = obj.method(z); `