### PR TITLE
C++ Basic Array implementation (CrossComponentInheritance)

### DIFF
--- a/Source/buildimplementationcpp.go
+++ b/Source/buildimplementationcpp.go
@@ -1804,7 +1804,6 @@ func generatePrePostCallCPPFunctionCode(component ComponentDefinition, method Co
 			case "basicarray":
 				checkInputCode = append(checkInputCode, fmt.Sprintf("if ( (!p%sBuffer) && (n%sBufferSize>0))", param.ParamName, param.ParamName))
 				checkInputCode = append(checkInputCode, fmt.Sprintf("  throw %s (%s_ERROR_INVALIDPARAM);", exceptionType, strings.ToUpper(NameSpace)))
-				callParameters = callParameters + fmt.Sprintf("n%sBufferSize, ", param.ParamName) + variableName
 				if (isClientImpl) {
 					callParameters = callParameters + fmt.Sprintf("%sInputVector(%s, n%sBufferSize)", ClassIdentifier, variableName, param.ParamName) 
 				} else {


### PR DESCRIPTION
# Problem
Using a basic array with the CrossComponentInheritance branch results in the generated C++ code not compiling, as one of the function call uses provides additional parameters compared to the definition it was compiling against. The resulting output also blends two names together, resulting in the compiler trying to find an unrecognised object.

# Solution
Remove the line which incorrectly adds the extra call parameters.