### PR TITLE
Automatically update when a reserved keyword is used as an enum in ACT (Python bindings)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ debug
 .vscode
 
 .DS_Store
+
+# Jetbrains
+.idea/

--- a/Source/automaticcomponenttoolkit.go
+++ b/Source/automaticcomponenttoolkit.go
@@ -732,10 +732,13 @@ func main() {
 	
 	err = createComponent(component, outfolderBase, bindingsDirectoryOverride, interfacesDirectoryOverride, stubDirectoryOverride, suppressBindings, suppressStub, suppressInterfaces, suppressSubcomponents, suppressLicense, suppressExamples)
 	if (err != nil) {
-		log.Println("Fatal error")
-		log.Fatal(err)
+		if err == ErrPythonBuildFailed {
+			log.Println("Python binding generation failed (Due to usage of reserved keywords)")
+		} else {
+			log.Println("Fatal error")
+			log.Fatal(err)
+		}
 	} else {
 		log.Println("Success")
 	}
-
 }

--- a/Source/buildbindingpython.go
+++ b/Source/buildbindingpython.go
@@ -41,6 +41,15 @@ import (
 	"strings"
 )
 
+// Keep a map of reserved keywords in Python
+var pythonReservedKeywords = map[string]bool{
+	"False": true, "None": true, "True": true, "and": true, "as": true, "assert": true, "async": true,
+	"await": true, "break": true, "class": true, "continue": true, "def": true, "del": true, "elif": true,
+	"else": true, "except": true, "finally": true, "for": true, "from": true, "global": true, "if": true,
+	"import": true, "in": true, "is": true, "lambda": true, "nonlocal": true, "not": true, "or": true,
+	"pass": true, "raise": true, "return": true, "try": true, "while": true, "with": true, "yield": true,
+}
+
 // BuildBindingPythonDynamic builds dynamic Python bindings of a library's API in form of explicitly loaded
 // functions handles.
 func BuildBindingPythonDynamic(componentdefinition ComponentDefinition, outputFolder string, outputFolderExample string, indentString string) error {
@@ -179,7 +188,12 @@ func buildDynamicPythonImplementation(componentdefinition ComponentDefinition, w
 			w.Writeln("class %s(CTypesEnum):", enum.Name)
 			for j:= 0; j<len(enum.Options); j++ {
 				option := enum.Options[j]
-				w.Writeln("  %s = %d", option.Name, option.Value)
+				if pythonReservedKeywords[option.Name] {
+					log.Printf("Invalid enum datatype as \"%s\" is a reserved keyword in Python. Replacing it with \"%s\"", option.Name, enum.Name + option.Name)
+					w.Writeln("  %s = %d", enum.Name + option.Name, option.Value)
+				} else {
+					w.Writeln("  %s = %d", option.Name, option.Value)
+				}
 			}
 		}
 		w.Writeln("")

--- a/Source/buildbindingpython.go
+++ b/Source/buildbindingpython.go
@@ -41,14 +41,9 @@ import (
 	"strings"
 )
 
-// Keep a map of reserved keywords in Python
-var pythonReservedKeywords = map[string]bool{
-	"False": true, "None": true, "True": true, "and": true, "as": true, "assert": true, "async": true,
-	"await": true, "break": true, "class": true, "continue": true, "def": true, "del": true, "elif": true,
-	"else": true, "except": true, "finally": true, "for": true, "from": true, "global": true, "if": true,
-	"import": true, "in": true, "is": true, "lambda": true, "nonlocal": true, "not": true, "or": true,
-	"pass": true, "raise": true, "return": true, "try": true, "while": true, "with": true, "yield": true,
-}
+// Store the python file path
+var pythonBindingFile = "";
+
 
 // BuildBindingPythonDynamic builds dynamic Python bindings of a library's API in form of explicitly loaded
 // functions handles.
@@ -59,6 +54,7 @@ func BuildBindingPythonDynamic(componentdefinition ComponentDefinition, outputFo
 	libraryname := componentdefinition.LibraryName
 	
 	DynamicPythonImpl := path.Join(outputFolder, namespace+".py");
+	pythonBindingFile = DynamicPythonImpl;
 	log.Printf("Creating \"%s\"", DynamicPythonImpl)
 	dynpythonfile, err := CreateLanguageFile (DynamicPythonImpl, indentString)
 	if err != nil {
@@ -71,6 +67,9 @@ func BuildBindingPythonDynamic(componentdefinition ComponentDefinition, outputFo
 	
 	err = buildDynamicPythonImplementation(componentdefinition, dynpythonfile)
 	if err != nil {
+		if err == ErrReservedKeyword {
+			return ErrPythonBuildFailed
+		}
 		return err;
 	}
 	
@@ -150,6 +149,9 @@ func buildDynamicPythonImplementation(componentdefinition ComponentDefinition, w
 	w.Writeln("  SUCCESS = 0")
 	for i := 0; i<len(componentdefinition.Errors.Errors); i++ {
 		merror := componentdefinition.Errors.Errors[i]
+		if pythonReservedKeywords[merror.Name] {
+			return ReservedKeywordExit(pythonBindingFile, "Error code uses a reserved keyword : %s", merror.Name)
+		}
 		w.Writeln("  %s = %d", merror.Name, merror.Code)
 	}
 	w.Writeln("")
@@ -183,6 +185,9 @@ func buildDynamicPythonImplementation(componentdefinition ComponentDefinition, w
 
 		for i := 0; i<len(componentdefinition.Enums); i++ {
 			enum := componentdefinition.Enums[i]
+			if pythonReservedKeywords[enum.Name] {
+				return ReservedKeywordExit(pythonBindingFile, "Class name for enum uses a reserved keyword : %s", enum.Name)
+			}
 			w.Writeln("'''Definition of %s", enum.Name)
 			w.Writeln("'''")
 			w.Writeln("class %s(CTypesEnum):", enum.Name)
@@ -204,6 +209,9 @@ func buildDynamicPythonImplementation(componentdefinition ComponentDefinition, w
 		w.Writeln("'''")
 		for i := 0; i<len(componentdefinition.Structs); i++ {
 			_struct := componentdefinition.Structs[i]
+			if pythonReservedKeywords[_struct.Name] {
+				return ReservedKeywordExit(pythonBindingFile, "Class name for the structure uses a reserved keyword : %s", _struct.Name)
+			}
 			w.Writeln("'''Definition of %s", _struct.Name)
 			w.Writeln("'''")
 			w.Writeln("class %s(ctypes.Structure):", _struct.Name)
@@ -245,6 +253,9 @@ func buildDynamicPythonImplementation(componentdefinition ComponentDefinition, w
 		w.Writeln("'''")
 		for i := 0; i<len(componentdefinition.Functions); i++ {
 			_func := componentdefinition.Functions[i]
+			if pythonReservedKeywords[_func.FunctionName] {
+				return ReservedKeywordExit(pythonBindingFile, "Function type definition uses a reserved keyword : %s", _func.FunctionName)
+			}
 			w.Writeln("'''Definition of %s", _func.FunctionName)
 			w.Writeln("    %s", _func.FunctionDescription)
 			w.Writeln("'''")
@@ -464,7 +475,9 @@ func writeFunctionTableMethod(method ComponentDefinitionMethod, w LanguageWriter
 	if err != nil {
 		return err
 	}
-
+	if pythonReservedKeywords[linearMethodName] {
+		return ReservedKeywordExit(pythonBindingFile, "Method name uses a reserved keyword : %s", linearMethodName)
+	}
 	w.Writeln("err = symbolLookupMethod(ctypes.c_char_p(str.encode(\"%s\")), methodAddress)", linearMethodName)
 	w.Writeln("if err != 0:")
 	w.Writeln("  raise E%sException(ErrorCodes.COULDNOTLOADLIBRARY, str(err))", NameSpace)
@@ -764,7 +777,9 @@ func generateCTypesParameter(param ComponentDefinitionParam, className string, m
 
 func writePythonClass(component ComponentDefinition, class ComponentDefinitionClass, w LanguageWriter, NameSpace string) error {
 	pythonBaseClassName := fmt.Sprintf("%s", component.Global.BaseClassName)
-
+	if pythonReservedKeywords[pythonBaseClassName] {
+		return ReservedKeywordExit(pythonBindingFile, "Class implementation name uses a reserved keyword : %s", pythonBaseClassName)
+	}
 	w.Writeln("''' Class Implementation for %s",  class.ClassName)
 	w.Writeln("'''")
 	
@@ -778,8 +793,14 @@ func writePythonClass(component ComponentDefinition, class ComponentDefinitionCl
 		w.Writeln("class %s(%s):", class.ClassName, parentClass)
 		w.Writeln("  def __init__(self, handle, wrapper):")
 		w.Writeln("    %s.__init__(self, handle, wrapper)", parentClass)
+		if pythonReservedKeywords[class.ClassName] || pythonReservedKeywords[parentClass] {
+			return ReservedKeywordExit(pythonBindingFile, "Class implementation name uses a reserved keyword : %s, %s", class.ClassName, parentClass)
+		}
 
 	} else {
+		if pythonReservedKeywords[class.ClassName] {
+			return ReservedKeywordExit(pythonBindingFile, "Class implementation name uses a reserved keyword : %s", class.ClassName)
+		}
 		w.Writeln("class %s:", class.ClassName)
 
 		w.Writeln("  def __init__(self, handle, wrapper):")
@@ -1016,7 +1037,9 @@ func writeMethod(method ComponentDefinitionMethod, w LanguageWriter, NameSpace s
 	}
 	
 	exportName := GetCExportName(NameSpace, ClassName, method, isGlobal)
-	
+	if pythonReservedKeywords[method.MethodName] {
+		return ReservedKeywordExit(pythonBindingFile, "Method name uses a reserved keyword : %s", method.MethodName)
+	}
 	w.Writeln("  def %s(self%s):", method.MethodName, pythonInParams)
 	w.Writelns("    ", preCallLines)
 	if (doCheckCall) {


### PR DESCRIPTION
This patch maintains a dictionary of Python keywords, which can be obtained using the following code:

```
Python 3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import keyword
>>> keyword.kwlist
['False', 'None', 'True', 'and', 'as', 'assert', 'async', 'await', 'break', 'class', 'continue', 'def', 'del', 'elif', 'else', 'except', 'finally', 'for', 'from', 'global', 'if', 'import', 'in', 'is', 'lambda', 'nonlocal', 'not', 'or', 'pass', 'raise', 'return', 'try', 'while', 'with', 'yield']
```

This patch warns the user and automatically changes the **enum LHS** to **enum_name + enum_option_name.** It fixes the issue (https://github.com/Autodesk/AutomaticComponentToolkit/issues/145) in lib3mf immediately. The scope of this needs to be expanded to the rest of the code. I believe it is even better to check the XML file at the beginning and produce a modified XML file to avoid any changes to ACT code. That would be a more feasible option. Feedback is welcome.