### PR TITLE
Add c++ binding/implementation thread safety options v2

### DIFF
--- a/Source/automaticcomponenttoolkit.go
+++ b/Source/automaticcomponenttoolkit.go
@@ -584,7 +584,7 @@ func printUsageInfo() {
 }
 
 func main() {
-	ACTVersion := "1.8.0-alpha"
+	ACTVersion := "1.8.1-alpha"
 	fmt.Fprintln(os.Stdout, "Automatic Component Toolkit v"+ACTVersion)
 	if len(os.Args) < 2 {
 		printUsageInfo()
@@ -683,6 +683,11 @@ func main() {
 	err = component.CheckComponentDefinition()
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	addExtraBaseClassMethods := component.addExtraBaseClassMethods()
+	if addExtraBaseClassMethods != nil {
+		log.Printf("%s", *addExtraBaseClassMethods)
 	}
 
 	if mode == eACTModeDiff {

--- a/Source/buildbindingccpp.go
+++ b/Source/buildbindingccpp.go
@@ -591,7 +591,7 @@ func writeDynamicCPPMethodDeclaration(method ComponentDefinitionMethod, w Langua
 }
 
 func writeDynamicCPPMethod(method ComponentDefinitionMethod, w LanguageWriter, NameSpace string, ClassIdentifier string, ClassName string,
-	implementationLines []string, isGlobal bool, includeComments bool, doNotThrow bool, useCPPTypes bool, ExplicitLinking bool, forWASM bool) error {
+	implementationLines []string, isGlobal bool, includeComments bool, doNotThrow bool, useCPPTypes bool, ExplicitLinking bool, forWASM bool, multiThreadedEnv bool, classThreadSafetyOption ThreadSafetyOption) error {
 
 	WASMPrefix := ""
 	WASMCast := ""
@@ -615,6 +615,14 @@ func writeDynamicCPPMethod(method ComponentDefinitionMethod, w LanguageWriter, N
 	checkErrorCodeBegin := ""
 	checkErrorCodeEnd := ")"
 	makeSharedParameter := ""
+
+	if multiThreadedEnv && !isGlobal {
+		if classThreadSafetyOption == eThreadSafetyStrict {
+			checkErrorCodeEnd = ", true)"
+		} else {
+			checkErrorCodeEnd = ", false)"
+		}
+	}
 
 	if isGlobal {
 		if ExplicitLinking {
@@ -858,6 +866,12 @@ func writeDynamicCPPMethod(method ComponentDefinitionMethod, w LanguageWriter, N
 		initCallParameters = initCallParameters + initCallParameter
 	}
 
+	addThreadSafeCalls := multiThreadedEnv && !isGlobal && ((classThreadSafetyOption == eThreadSafetySoft && requiresInitCall) || classThreadSafetyOption == eThreadSafetyStrict)
+
+	if addThreadSafeCalls {
+		checkErrorCodeEnd = ", true)"
+	}
+
 	w.Writeln("  ")
 	if includeComments {
 		w.Writeln("  /**")
@@ -876,6 +890,11 @@ func writeDynamicCPPMethod(method ComponentDefinitionMethod, w LanguageWriter, N
 
 	w.Writeln("  {")
 	w.Writelns("    ", definitionCodeLines)
+
+	if addThreadSafeCalls {
+		w.Writeln("    %s();", getLockInstanceMethodName())
+	}
+
 	if requiresInitCall {
 		w.Writeln("    %s%s(%s)%s;", checkErrorCodeBegin, CMethodName, initCallParameters, checkErrorCodeEnd)
 	}
@@ -886,6 +905,10 @@ func writeDynamicCPPMethod(method ComponentDefinitionMethod, w LanguageWriter, N
 	if len(implementationLines) > 0 {
 		w.Writeln("    ")
 		w.Writelns("    ", implementationLines)
+	}
+
+	if addThreadSafeCalls {
+		w.Writeln("    %s();", getUnlockInstanceMethodName())
 	}
 
 	if len(returnCodeLines) > 0 {
@@ -905,11 +928,20 @@ func writeDynamicCppBaseClassMethods(component ComponentDefinition, baseClass Co
 	w.Writeln("  /* Handle to Instance in library*/")
 	w.Writeln("  %sHandle m_pHandle;", NameSpace)
 	w.Writeln("")
-	w.Writeln("  /* Checks for an Error code and raises Exceptions */")
-	w.Writeln("  void CheckError(%sResult nResult)", NameSpace)
+	if component.isMultiThreadedEnv() {
+		w.Writeln("  /* Checks for an Error code, raises Exceptions and unlocks library object*/")
+		w.Writeln("  void CheckError(%sResult nResult, bool unlockIfError)", NameSpace)
+	} else {
+		w.Writeln("  /* Checks for an Error code and raises Exceptions */")
+		w.Writeln("  void CheckError(%sResult nResult)", NameSpace)
+	}
 	w.Writeln("  {")
 	w.Writeln("    if (m_pWrapper != nullptr)")
-	w.Writeln("      m_pWrapper->CheckError(this, nResult);")
+	if component.isMultiThreadedEnv() {
+		w.Writeln("      m_pWrapper->CheckError(this, nResult, unlockIfError);")
+	} else {
+		w.Writeln("      m_pWrapper->CheckError(this, nResult);")
+	}
 	w.Writeln("  }")
 	w.Writeln("public:")
 	w.Writeln("  /**")
@@ -1390,19 +1422,42 @@ func writeClassDeclarations(w LanguageWriter, component ComponentDefinition, cpp
 			w.Writeln("  {")
 			w.Writeln("  }")
 			w.Writeln("  ")
+
+			for _, method := range class.Methods {
+				err := writeDynamicCPPMethodDeclaration(method, w, NameSpace, ClassIdentifier, cppClassName)
+				if err != nil {
+					return err
+				}
+			}
+
 		} else {
 			err := writeDynamicCppBaseClassMethods(component, baseClass, w, NameSpace, BaseName, cppClassPrefix, ClassIdentifier)
 			if err != nil {
 				return err
 			}
-		}
 
-		for _, method := range class.Methods {
-			err := writeDynamicCPPMethodDeclaration(method, w, NameSpace, ClassIdentifier, cppClassName)
-			if err != nil {
-				return err
+			extraBaseClassMethods := []ComponentDefinitionMethod{}
+			for _, method := range class.Methods {
+				if method.isExtraBaseClassmethod() {
+					extraBaseClassMethods = append(extraBaseClassMethods, method)
+				} else {
+					err := writeDynamicCPPMethodDeclaration(method, w, NameSpace, ClassIdentifier, cppClassName)
+					if err != nil {
+						return err
+					}
+				}
+			}
+
+			w.Writeln("  ")
+			w.Writeln("protected:")
+			for _, method := range extraBaseClassMethods {
+				err := writeDynamicCPPMethodDeclaration(method, w, NameSpace, ClassIdentifier, cppClassName)
+				if err != nil {
+					return err
+				}
 			}
 		}
+		
 		w.Writeln("};")
 	}
 	return nil
@@ -1450,13 +1505,22 @@ func writePolymorphicFactoryImplementation(w LanguageWriter, component Component
 	w.Writeln("}")
 }
 
-func writeCheckErrorImplementation(w LanguageWriter, ErrorMethodName string, ClassIdentifier string, cppBaseClassName string, NameSpace string) {
-	w.Writeln("  inline void C%sWrapper::CheckError(%s * pBaseClass, %sResult nResult)", ClassIdentifier, cppBaseClassName, NameSpace)
+func writeCheckErrorImplementation(w LanguageWriter, ErrorMethodName string, ClassIdentifier string, cppBaseClassName string, NameSpace string, multiThreadedEnv bool) {
+	if multiThreadedEnv {
+		w.Writeln("  inline void C%sWrapper::CheckError(%s * pBaseClass, %sResult nResult, bool unlockIfError)", ClassIdentifier, cppBaseClassName, NameSpace)
+	} else {
+		w.Writeln("  inline void C%sWrapper::CheckError(%s * pBaseClass, %sResult nResult)", ClassIdentifier, cppBaseClassName, NameSpace)
+	}
 	w.Writeln("  {")
 	w.Writeln("    if (nResult != 0) {")
 	w.Writeln("      std::string sErrorMessage;")
 	w.Writeln("      if (pBaseClass != nullptr) {")
 	w.Writeln("        %s(pBaseClass, sErrorMessage);", ErrorMethodName)
+	if multiThreadedEnv {
+		w.Writeln("        if (unlockIfError) {")
+		w.Writeln("          pBaseClass->%s();", getUnlockInstanceMethodName())
+		w.Writeln("        }")
+	}
 	w.Writeln("      }")
 	w.Writeln("      throw E%sException(nResult, sErrorMessage);", NameSpace)
 	w.Writeln("    }")
@@ -1539,7 +1603,11 @@ func buildCppHeader(component ComponentDefinition, w LanguageWriter, NameSpace s
 	writeWrapperLifeTimeHandling(w, cppClassPrefix, ClassIdentifier, ExplicitLinking)
 
 	w.Writeln("  ")
-	w.Writeln("  inline void CheckError(%s * pBaseClass, %sResult nResult);", cppBaseClassName, NameSpace)
+	if component.isMultiThreadedEnv() {
+		w.Writeln("  inline void CheckError(%s * pBaseClass, %sResult nResult, bool unlockIfError = false);", cppBaseClassName, NameSpace)
+	} else {
+		w.Writeln("  inline void CheckError(%s * pBaseClass, %sResult nResult);", cppBaseClassName, NameSpace)
+	}
 	w.Writeln("")
 
 	for j := 0; j < len(global.Methods); j++ {
@@ -1622,7 +1690,7 @@ func buildCppHeader(component ComponentDefinition, w LanguageWriter, NameSpace s
 			implementationLines = append(implementationLines, fmt.Sprintf("  throw E%sException(%s_ERROR_COULDNOTLOADLIBRARY, \"Unknown namespace \" + %s);", NameSpace, strings.ToUpper(NameSpace), sParamName))
 		}
 
-		err = writeDynamicCPPMethod(method, w, NameSpace, ClassIdentifier, "Wrapper", implementationLines, true, true, false, useCPPTypes, ExplicitLinking, false)
+		err = writeDynamicCPPMethod(method, w, NameSpace, ClassIdentifier, "Wrapper", implementationLines, true, true, false, useCPPTypes, ExplicitLinking, false, component.isMultiThreadedEnv(), eThreadSafetyNone)
 		if err != nil {
 			return err
 		}
@@ -1630,7 +1698,7 @@ func buildCppHeader(component ComponentDefinition, w LanguageWriter, NameSpace s
 	}
 
 	w.Writeln("")
-	writeCheckErrorImplementation(w, component.Global.ErrorMethod, ClassIdentifier, cppBaseClassName, NameSpace)
+	writeCheckErrorImplementation(w, component.Global.ErrorMethod, ClassIdentifier, cppBaseClassName, NameSpace, component.isMultiThreadedEnv())
 	w.Writeln("")
 
 	if ExplicitLinking {
@@ -1648,7 +1716,7 @@ func buildCppHeader(component ComponentDefinition, w LanguageWriter, NameSpace s
 		w.Writeln("   */")
 		for j := 0; j < len(class.Methods); j++ {
 			method := class.Methods[j]
-			err := writeDynamicCPPMethod(method, w, NameSpace, ClassIdentifier, class.ClassName, make([]string, 0), false, true, false, useCPPTypes, ExplicitLinking, false)
+			err := writeDynamicCPPMethod(method, w, NameSpace, ClassIdentifier, class.ClassName, make([]string, 0), false, true, false, useCPPTypes, ExplicitLinking, false, component.isMultiThreadedEnv(), class.eThreadSafetyOption())
 			if err != nil {
 				return err
 			}
@@ -2217,14 +2285,14 @@ func buildCppwasmGuestHeader(component ComponentDefinition, w LanguageWriter, Na
 			implementationLines = append(implementationLines, fmt.Sprintf("  throw E%sException(%s_ERROR_COULDNOTLOADLIBRARY, \"Unknown namespace \" + %s);", NameSpace, strings.ToUpper(NameSpace), sParamName))
 		}
 
-		err = writeDynamicCPPMethod(method, w, NameSpace, ClassIdentifier, "Wrapper", implementationLines, true, true, false, useCPPTypes, ExplicitLinking, true)
+		err = writeDynamicCPPMethod(method, w, NameSpace, ClassIdentifier, "Wrapper", implementationLines, true, true, false, useCPPTypes, ExplicitLinking, true, false, eThreadSafetyNone)
 		if err != nil {
 			return err
 		}
 	}
 
 	w.Writeln("")
-	writeCheckErrorImplementation(w, component.Global.ErrorMethod, ClassIdentifier, cppBaseClassName, NameSpace)
+	writeCheckErrorImplementation(w, component.Global.ErrorMethod, ClassIdentifier, cppBaseClassName, NameSpace, false)
 	w.Writeln("")
 
 	for i := 0; i < len(component.Classes); i++ {
@@ -2236,7 +2304,7 @@ func buildCppwasmGuestHeader(component ComponentDefinition, w LanguageWriter, Na
 		w.Writeln("   */")
 		for j := 0; j < len(class.Methods); j++ {
 			method := class.Methods[j]
-			err := writeDynamicCPPMethod(method, w, NameSpace, ClassIdentifier, class.ClassName, make([]string, 0), false, true, false, useCPPTypes, ExplicitLinking, true)
+			err := writeDynamicCPPMethod(method, w, NameSpace, ClassIdentifier, class.ClassName, make([]string, 0), false, true, false, useCPPTypes, ExplicitLinking, true, false, eThreadSafetyNone)
 			if err != nil {
 				return err
 			}

--- a/Source/buildimplementationcpp.go
+++ b/Source/buildimplementationcpp.go
@@ -314,6 +314,39 @@ func writeSharedPtrTemplate(component ComponentDefinition, w LanguageWriter, Cla
 	w.Writeln("")
 }
 
+func getWithMutexClassName(ClassIdentifier string, ClassName string) (string) {
+	return ClassIdentifier + ClassName + "WithMutex"
+}
+
+func writeBaseInterfaceWithMutexClass(baseClass ComponentDefinitionClass, w LanguageWriter, ClassIdentifier string) {
+	baseClassName:= "I" + baseClass.ClassName
+	className := "I" + getWithMutexClassName(ClassIdentifier, baseClass.ClassName)
+	lockInstanceMethod := LockInstanceMethod()
+	unlockInstanceMethod := UnlockInstanceMethod()
+
+	w.Writeln("")
+	w.Writeln("/**")
+	w.Writeln(" Definition of a class with mutex for %s", baseClassName)
+	w.Writeln("*/")
+	w.Writeln("class %s : public virtual %s", className, baseClassName)
+	w.Writeln("{")
+	w.Writeln("private:")
+	w.Writeln("  std::mutex m_mutex;")
+	w.Writeln("public:")
+	w.Writeln("")
+	w.Writeln("  /**")
+	w.Writeln("  * %s::%s - %s", className, lockInstanceMethod.MethodName, lockInstanceMethod.MethodDescription)
+	w.Writeln("  */")
+	w.Writeln("  virtual void %s() { m_mutex.lock(); }", lockInstanceMethod.MethodName)	
+	w.Writeln("")
+	w.Writeln("  /**")
+	w.Writeln("  * %s::%s - %s", className, unlockInstanceMethod.MethodName, unlockInstanceMethod.MethodDescription)
+	w.Writeln("  */")
+	w.Writeln("  virtual void %s() { m_mutex.unlock();}", unlockInstanceMethod.MethodName)	
+	w.Writeln("};")
+	w.Writeln("")
+}
+
 func writeCPPClassInterface(component ComponentDefinition, class ComponentDefinitionClass, w LanguageWriter, NameSpace string, NameSpaceImplementation string, ClassIdentifier string, BaseName string) (error) {
 	w.Writeln("")
 	w.Writeln("/*************************************************************************************************************************")
@@ -324,7 +357,11 @@ func writeCPPClassInterface(component ComponentDefinition, class ComponentDefini
 	if (!component.isBaseClass(class)) {
 		parentClassString = " : public virtual "
 		if (class.ParentClass == "") {
-			parentClassString += fmt.Sprintf("I%s%s ", ClassIdentifier, component.Global.BaseClassName)
+			if (class.isThreadSafe()) {
+				parentClassString += fmt.Sprintf("I%s ", getWithMutexClassName(ClassIdentifier, component.Global.BaseClassName))
+			} else {
+				parentClassString += fmt.Sprintf("I%s%s ", ClassIdentifier, component.Global.BaseClassName)
+			}
 		} else {
 			parentClassString += fmt.Sprintf("I%s%s ", ClassIdentifier, class.ParentClass)
 		}
@@ -334,9 +371,8 @@ func writeCPPClassInterface(component ComponentDefinition, class ComponentDefini
 	w.Writeln("class %s%s{", classInterfaceName, parentClassString)
 
 	if (component.isStringOutBaseClass(class)) {
-		w.Writeln("private:")
-		w.Writeln("  std::unique_ptr<ParameterCache> m_ParameterCache;")
-	
+		w.Writeln("protected:")
+		w.Writeln("  std::unique_ptr<ParameterCache> m_ParameterCache;")	
 	}
 
 	w.Writeln("public:")
@@ -411,7 +447,23 @@ func writeCPPClassInterface(component ComponentDefinition, class ComponentDefini
 		w.Writeln("  {")	
 		w.Writeln("    return m_ParameterCache.get();")	
 		w.Writeln("  }")	
-		w.Writeln("")			
+		w.Writeln("")
+		
+		if component.isMultiThreadedEnv() {
+			lockInstanceMethod := LockInstanceMethod()
+			w.Writeln("  /**")
+			w.Writeln("  * %s::%s - %s", classInterfaceName, lockInstanceMethod.MethodName, lockInstanceMethod.MethodDescription)
+			w.Writeln("  */")
+			w.Writeln("  virtual void %s() {}", lockInstanceMethod.MethodName)		
+			w.Writeln("")
+
+			unlockInstanceMethod := UnlockInstanceMethod()
+			w.Writeln("  /**")
+			w.Writeln("  * %s::%s - %s", classInterfaceName, unlockInstanceMethod.MethodName, unlockInstanceMethod.MethodDescription)
+			w.Writeln("  */")
+			w.Writeln("  virtual void %s() {}", unlockInstanceMethod.MethodName)		
+			w.Writeln("")
+		}
 	}
 
 	if (component.isBaseClass(class)) {
@@ -440,6 +492,11 @@ func writeCPPClassInterface(component ComponentDefinition, class ComponentDefini
 		if method.MethodName == component.Global.ClassTypeIdMethod {
 			continue
 		}
+
+		if component.isBaseClass(class) && method.isExtraBaseClassmethod() {
+			continue
+		}
+
 		methodstring, _, err := buildCPPInterfaceMethodDeclaration(method, class.ClassName, NameSpace, ClassIdentifier, BaseName, w.IndentString, false, true, true)
 		if err != nil {
 			return err
@@ -452,6 +509,9 @@ func writeCPPClassInterface(component ComponentDefinition, class ComponentDefini
 
 	if component.isBaseClass(class) {
 		writeSharedPtrTemplate(component, w, ClassIdentifier)
+		if component.isMultiThreadedEnv() {
+			writeBaseInterfaceWithMutexClass(class, w, ClassIdentifier)
+		}
 	}
 
 	w.Writeln("")
@@ -535,6 +595,9 @@ func buildCPPInterfaces(component ComponentDefinition, w LanguageWriter, NameSpa
 
 	w.Writeln("#include <string>")
 	w.Writeln("#include <memory>")
+	if component.isMultiThreadedEnv() {
+		w.Writeln("#include <mutex>")
+	}
 	w.Writeln("")
 	w.Writeln("#include \"%s_types.hpp\"", BaseName)
 	w.Writeln("")

--- a/Source/componentdefinition.go
+++ b/Source/componentdefinition.go
@@ -62,6 +62,13 @@ const (
 	eSpecialMethodBuildinfo = 9
 )
 
+type ThreadSafetyOption int
+const (
+	eThreadSafetyNone   = 0
+	eThreadSafetySoft   = 1
+	eThreadSafetyStrict = 2
+)
+
 // ComponentDefinitionParam definition of a method parameter used in the component's API
 type ComponentDefinitionParam struct {
 	ComponentDiffableElement
@@ -90,6 +97,7 @@ type ComponentDefinitionClass struct {
 	ClassName string `xml:"name,attr"`
 	ClassDescription string `xml:"description,attr"`
 	ParentClass string `xml:"parent,attr"`
+	ThreadSafetyOption string `xml:"threadsafetyoption,attr"`
 	Methods   []ComponentDefinitionMethod `xml:"method"`
 }
 
@@ -345,6 +353,26 @@ func ReadComponentDefinition(FileName string, ACTVersion string) (ComponentDefin
 	return component, nil
 }
 
+func (component *ComponentDefinition) addExtraBaseClassMethods() *string {
+	if component.isMultiThreadedEnv() {
+		for i := 0; i < len(component.Classes); i++ {
+			class := component.Classes[i]
+			if component.isBaseClass(class) {
+				msg := fmt.Sprintf("Mutli threaded implementation detected, adding %s, %s", getLockInstanceMethodName(), getUnlockInstanceMethodName())
+				class.Methods = append(class.Methods, LockInstanceMethod(), UnlockInstanceMethod())
+				component.Classes[i] = class
+				return &msg
+			}
+		}
+	}
+
+	return nil
+}
+
+func (method *ComponentDefinitionMethod) isExtraBaseClassmethod() bool {
+	return method.MethodName == getLockInstanceMethodName() || method.MethodName == getUnlockInstanceMethodName()
+}
+
 func getIndentationString(str string) string {
 	if str == "tabs" {
 		return "\t";
@@ -522,6 +550,9 @@ func (component *ComponentDefinition) checkClasses() (error) {
 	for i := 0; i < len(classes); i++ {
 		class := classes[i];
 		classTypeHash, _ := class.classTypeId(component.NameSpace);
+		if component.isBaseClass(class) && class.isThreadSafe() {
+			return fmt.Errorf("thread safety option for base class can't be enabled")
+		}
 		if !nameIsValidIdentifier(class.ClassName) {
 			return fmt.Errorf ("invalid class name \"%s\"", class.ClassName);
 		}
@@ -530,6 +561,9 @@ func (component *ComponentDefinition) checkClasses() (error) {
 		}
 		if len(class.ClassDescription) > 0 && !descriptionIsValid(class.ClassDescription) {
 			return fmt.Errorf ("invalid class description \"%s\" in class \"%s\"", class.ClassDescription, class.ClassName);
+		}
+		if len(class.ThreadSafetyOption) > 0 && !threadSafetyOptionIsValid(class.ThreadSafetyOption) {
+			return fmt.Errorf("invalid class thread safety option \"%s\" in class \"%s\"", class.ThreadSafetyOption, class.ClassName)
 		}
 		collision, hashExists := classTypeIdIndex[classTypeHash]
 		if hashExists {
@@ -568,7 +602,7 @@ func (component *ComponentDefinition) checkClasses() (error) {
 	return nil
 }
 
-func (component *ComponentDefinition) checkFunctionTypes() ( error) {
+func (component *ComponentDefinition) checkFunctionTypes() (error) {
 	functions := component.Functions
 	var functionNameList = &component.NameMapsLookup.functionTypeMap
 
@@ -794,6 +828,14 @@ func descriptionIsValid(description string) bool {
 		return IsValidMethodDescription(description);
 	}
 	return false;
+}
+
+func threadSafetyOptionIsValid(threadSafetyOption string) bool {
+	switch threadSafetyOption {
+	case "none", "strict", "soft":
+		return true
+	}
+	return false
 }
 
 func isScalarType(typeStr string) bool {
@@ -1272,6 +1314,32 @@ func (component *ComponentDefinition) isBaseClass(class ComponentDefinitionClass
 	return class.ClassName == component.Global.BaseClassName
 }
 
+func getLockInstanceMethodName() string {
+	return "_lockInstance"
+}
+
+// LockInstanceMethod returns the xml definition of the LockInstanceMethod
+func LockInstanceMethod() ComponentDefinitionMethod {
+	var method ComponentDefinitionMethod
+	source := fmt.Sprintf(`<method name="%s" description = "If thread safety for class in library is enabled it should lock object for calling thread">
+	</method>`, getLockInstanceMethodName())
+	xml.Unmarshal([]byte(source), &method)
+	return method
+}
+
+func getUnlockInstanceMethodName() string {
+	return "_unlockInstance"
+}
+
+// UnlockInstanceMethod returns the xml definition of the UnlockInstanceMethod
+func UnlockInstanceMethod() ComponentDefinitionMethod {
+	var method ComponentDefinitionMethod
+	source := fmt.Sprintf(`<method name="%s" description = "If thread safety for class in library is enabled it should unlock object for other threads">
+	</method>`, getUnlockInstanceMethodName())
+	xml.Unmarshal([]byte(source), &method)
+	return method
+}
+
 func (component *ComponentDefinition) baseClass() (ComponentDefinitionClass) {
 	for i := 0; i < len(component.Classes); i++ {
 		if (component.isBaseClass(component.Classes[i])) {
@@ -1363,6 +1431,33 @@ func (method *ComponentDefinitionMethod) getArrayOutParameters() ([]string) {
 	return outParameters;
 }
 
+func (class *ComponentDefinitionClass) eThreadSafetyOption() ThreadSafetyOption {
+	switch class.ThreadSafetyOption {
+	case "strict":
+		return eThreadSafetyStrict
+	case "soft":
+		return eThreadSafetySoft
+	case "none":
+		return eThreadSafetyNone
+	}
+	return eThreadSafetyNone
+}
+
+func (class *ComponentDefinitionClass) isThreadSafe() bool {
+	return class.eThreadSafetyOption() != eThreadSafetyNone
+}
+
+func (component *ComponentDefinition) isMultiThreadedEnv() bool {
+	classes := component.Classes
+	for i := 0; i < len(classes); i++ {
+		class := classes[i]
+		if class.isThreadSafe() {
+			return true
+		}
+	}
+
+	return false
+}
 
 func (class *ComponentDefinitionClass) countMaxOutParameters() (uint32) {
 


### PR DESCRIPTION
This solution adds 2 new virtual methods IBase::_lockInstance and IBase::_UnlockInstance on the implementation side with empty implementation. It also adds new class IBaseWithMutex that derives from Ibase. Those methods are being injected to base class methods so they will be exposed through and API (as private). It all happens only if one (or more) class has ThreadSafetyOption attribute set to "strict" or "soft".
Difference between soft and strict:
soft - binding side will call _lockInstance only if string / array is returned from API function
strict - binding side will call _lockInstance everytime, no matter what is returned from function

```
IBaseWithMutex Definition:
/**
 Definition of a class with mutex for IBase
*/
class IBaseWithMutex : public virtual IBase
{
private:
    std::mutex m_mutex;
public:

    /**
    * IBaseWithMutex::_lockInstance - If thread safety for class in library is enabled it should lock object for calling thread
    */
    virtual void _lockInstance() { m_mutex.lock(); }

    /**
    * IBaseWithMutex::_unlockInstance - If thread safety for class in library is enabled it should unlock object for other threads
    */
    virtual void _unlockInstance() { m_mutex.unlock();}
};
```

When ThreadSafetyOption attribute in LibraryManager component class is set to "soft" or "strict", ILibraryManager will derive from IBaseWithMutex instead of Ibase

```
class ILibraryManager : public virtual IBaseWithMutex {
public:
    ...
};
Example binding side functions created when ThreadSafetyOption is set to soft:
std::string CLibraryManager::GetLocalLibrariesPath()
{
    EagleAPI_uint32 bytesNeededPath = 0;
    EagleAPI_uint32 bytesWrittenPath = 0;
    _lockInstance();
    CheckError(m_pWrapper->m_WrapperTable.m_LibraryManager_GetLocalLibrariesPath(m_pHandle, 0, &bytesNeededPath, nullptr), true);
    std::vector<char> bufferPath(bytesNeededPath);
    CheckError(m_pWrapper->m_WrapperTable.m_LibraryManager_GetLocalLibrariesPath(m_pHandle, bytesNeededPath, &bytesWrittenPath, &bufferPath[0]), true);
    _unlockInstance();
    
    return std::string(&bufferPath[0]);
}

void CLibraryManager::RefreshLocalLibraries()
{
    CheckError(m_pWrapper->m_WrapperTable.m_LibraryManager_RefreshLocalLibraries(m_pHandle), false);
}
```
With this approach we are locking / unlocking mutex on implementation side so we can have 3 different instances of the Binding-Class pointing to the same Implementations-Class and all of this should work fine. On the binding side _lockInstance and _unlockInstance are private so one should use them by accident.
One more thing, CheckError will unlock hande in case of "exception propagation"
```
inline void CWrapper::CheckError(CBase * pBaseClass, EagleAPIResult nResult, bool unlockIfError)
    {
        if (nResult != 0) {
            std::string sErrorMessage;
            if (pBaseClass != nullptr) {
                GetLastError(pBaseClass, sErrorMessage);
                if (unlockIfError) {
                    _unlockInstance(pBaseClass);
                }
            }
            throw EEagleAPIException(nResult, sErrorMessage);
        }
    }
```
Just like with binding side, any changes on binding side will happen only when one (or more) class has ThreadSafetyOption attribute set to "strict" or "soft".