### PR TITLE
Fix an issue where C++ include header is in lowercase

### DIFF
--- a/Source/buildimplementationcpp.go
+++ b/Source/buildimplementationcpp.go
@@ -770,11 +770,11 @@ func buildCPPGetSymbolAddressMethod(component ComponentDefinition, w LanguageWri
 }
 
 func buildCPPInterfaceWrapper(component ComponentDefinition, w LanguageWriter, NameSpace string, NameSpaceImplementation string, ClassIdentifier string, BaseName string, doJournal bool) error {
-	w.Writeln("#include \"%s_abi.hpp\"", strings.ToLower(BaseName))
-	w.Writeln("#include \"%s_interfaces.hpp\"", strings.ToLower(BaseName))
-	w.Writeln("#include \"%s_interfaceexception.hpp\"", strings.ToLower(BaseName))
+	w.Writeln("#include \"%s_abi.hpp\"", BaseName)
+	w.Writeln("#include \"%s_interfaces.hpp\"", BaseName)
+	w.Writeln("#include \"%s_interfaceexception.hpp\"", BaseName)
 	if (doJournal) {
-		w.Writeln("#include \"%s_interfacejournal.hpp\"", strings.ToLower(BaseName))
+		w.Writeln("#include \"%s_interfacejournal.hpp\"", BaseName)
 	}
 	w.Writeln("")
 	w.Writeln("#include <map>")


### PR DESCRIPTION
The basename is used to generate the real files, including header files. When generating the include statement, the file name should be exactly the same as the physical file name, otherwise, it cannot be found on Linux, which is a case-sensitive OS.

For example, if the file name is 'BaseName_interface.hpp', the include statement should be '#include "BaseName_interface.hpp"' rather than '#include "basename_interface.hpp"'.