### PR TITLE
fix Python bindings: struct out param

### DIFF
--- a/Build/build.bat
+++ b/Build/build.bat
@@ -3,7 +3,7 @@ set startingDir="%CD%"
 set basepath="%~dp0"
 
 cd %basepath%\..\Source
-set Sources=actutils.go automaticcomponenttoolkit.go buildbindingccpp.go buildbindingccppdocumentation.go buildbindingcsharp.go buildbindinggo.go buildbindingnode.go buildbindingpascal.go buildbindingpython.go buildimplementationcpp.go buildbindingjava.go buildimplementationpascal.go componentdefinition.go componentdiff.go languagewriter.go languagec.go languagecpp.go languagepascal.go
+set Sources=actutils.go automaticcomponenttoolkit.go buildbindingccpp.go buildbindingccppdocumentation.go buildbindingcsharp.go buildbindinggo.go buildbindingnode.go buildbindingpascal.go buildbindingpython.go buildbindingwasm.go buildbindingjava.go buildimplementationcpp.go buildimplementationpascal.go componentdefinition.go componentdiff.go languagewriter.go languagec.go languagecpp.go languagepascal.go
 
 set GOOS=windows
 set GOARCH=amd64

--- a/Source/buildbindingpython.go
+++ b/Source/buildbindingpython.go
@@ -1005,7 +1005,7 @@ func writeMethod(method ComponentDefinitionMethod, w LanguageWriter, NameSpace s
 				{
 				outParamsSig = append(outParamsSig, param.ParamName+" = None")
 				
-				preCallLines = append(preCallLines, fmt.Sprintf("%s = %s(%s if %s else %s())", cParams[0].ParamName, cParams[0].ParamCallType, param.ParamName, param.ParamName, cParams[0].ParamCallType))
+				preCallLines = append(preCallLines, fmt.Sprintf("%s = %s if %s is not None else %s()", cParams[0].ParamName, param.ParamName, param.ParamName, cParams[0].ParamCallType))
 				cArguments = cArguments + cParams[0].ParamName
 				cCheckArguments = cCheckArguments  + cParams[0].ParamName
 				


### PR DESCRIPTION
Currently, when passing a struct as an out parameter, Python error:

`self = <AdProjectionSystem.BasicGeolocation object at 0x0000019D9F63BE00>, Value = None

    def GetGeographicReferencePoint(self, Value = None):
>       pValue = GeographicCoordinate(Value if Value else GeographicCoordinate())
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       TypeError: incompatible types, GeographicCoordinate instance instead of c_double instance`

This should be `pValue = Value if Value is not None else GeographicCoordinate()`. Therefore, I updated the Python binding accordingly. 

Checked extensively all the out params in lib3mf in this branch: https://github.com/3MFConsortium/lib3mf/blob/gangatp/python_out_params/SDK/Examples/Python/Lib3MF_Example.py

