### PR TITLE
Use specific class type instead of BaseClassName in ParameterCache template generation

### DIFF
--- a/Examples/RTTI/RTTI_component/Examples/Cpp/RTTI_example.cpp
+++ b/Examples/RTTI/RTTI_component/Examples/Cpp/RTTI_example.cpp
@@ -102,7 +102,7 @@ int main()
 
 		// Test GetNextOptionalAnimal - class out parameter with bool return
 		std::cout << std::endl;
-		std::cout << "Testing GetNextOptinalAnimal:" << std::endl;
+		std::cout << "Testing GetNextOptionalAnimal:" << std::endl;
 		auto iter2 = zoo->Iterator();
 		PAnimal optionalAnimal;
 		bool hasError;

--- a/Examples/RTTI/RTTI_component/Examples/Cpp/RTTI_example.cpp
+++ b/Examples/RTTI/RTTI_component/Examples/Cpp/RTTI_example.cpp
@@ -99,6 +99,48 @@ int main()
 		
 		animal = iter->GetNextAnimal();
 		assert(animal == nullptr);
+
+		// Test GetNextOptionalAnimal - class out parameter with bool return
+		std::cout << std::endl;
+		std::cout << "Testing GetNextOptinalAnimal:" << std::endl;
+		auto iter2 = zoo->Iterator();
+		PAnimal optionalAnimal;
+		bool hasError;
+		
+		hasError = iter2->GetNextOptinalAnimal(optionalAnimal);
+		assert(hasError == true);
+		assert(optionalAnimal != nullptr);
+		std::cout << "  Got animal: " << optionalAnimal->Name() << std::endl;
+		assert(std::dynamic_pointer_cast<CGiraffe>(optionalAnimal) != nullptr);
+		
+		hasError = iter2->GetNextOptinalAnimal(optionalAnimal);
+		assert(hasError == true);
+		assert(optionalAnimal != nullptr);
+		std::cout << "  Got animal: " << optionalAnimal->Name() << std::endl;
+		assert(std::dynamic_pointer_cast<CTiger>(optionalAnimal) != nullptr);
+		
+		std::cout << "✓ GetNextOptinalAnimal test passed" << std::endl;
+
+		// Test GetNextMandatoryAnimal - class out parameter with bool return
+		std::cout << std::endl;
+		std::cout << "Testing GetNextMandatoryAnimal:" << std::endl;
+		auto iter3 = zoo->Iterator();
+		PAnimal mandatoryAnimal;
+		
+		hasError = iter3->GetNextMandatoryAnimal(mandatoryAnimal);
+		assert(hasError == true);
+		assert(mandatoryAnimal != nullptr);
+		std::cout << "  Got animal: " << mandatoryAnimal->Name() << std::endl;
+		assert(std::dynamic_pointer_cast<CGiraffe>(mandatoryAnimal) != nullptr);
+		
+		hasError = iter3->GetNextMandatoryAnimal(mandatoryAnimal);
+		assert(hasError == true);
+		assert(mandatoryAnimal != nullptr);
+		std::cout << "  Got animal: " << mandatoryAnimal->Name() << std::endl;
+		assert(std::dynamic_pointer_cast<CTiger>(mandatoryAnimal) != nullptr);
+		
+		std::cout << "✓ GetNextMandatoryAnimal test passed" << std::endl;
+		std::cout << std::endl;
 	}
 	catch (std::exception &e)
 	{

--- a/Examples/RTTI/RTTI_component/Examples/CppDynamic/RTTI_example.cpp
+++ b/Examples/RTTI/RTTI_component/Examples/CppDynamic/RTTI_example.cpp
@@ -112,6 +112,50 @@ int main()
 		assert(animal == nullptr);
 
 		std::cout << "Trace 1" << std::endl;
+
+		// Test GetNextOptionalAnimal - class out parameter with bool return
+		std::cout << std::endl;
+		std::cout << "Testing GetNextOptinalAnimal:" << std::endl;
+		auto iter2 = zoo->Iterator();
+		PAnimal optionalAnimal;
+		bool hasError;
+		
+		hasError = iter2->GetNextOptinalAnimal(optionalAnimal);
+		assert(hasError == true);
+		assert(optionalAnimal != nullptr);
+		std::cout << "  Got animal: " << optionalAnimal->Name() << std::endl;
+		assert(std::dynamic_pointer_cast<CGiraffe>(optionalAnimal) != nullptr);
+		
+		hasError = iter2->GetNextOptinalAnimal(optionalAnimal);
+		assert(hasError == true);
+		assert(optionalAnimal != nullptr);
+		std::cout << "  Got animal: " << optionalAnimal->Name() << std::endl;
+		assert(std::dynamic_pointer_cast<CTiger>(optionalAnimal) != nullptr);
+		
+		std::cout << "✓ GetNextOptinalAnimal test passed" << std::endl;
+
+		// Test GetNextMandatoryAnimal - class out parameter with bool return
+		std::cout << std::endl;
+		std::cout << "Testing GetNextMandatoryAnimal:" << std::endl;
+		auto iter3 = zoo->Iterator();
+		PAnimal mandatoryAnimal;
+		
+		hasError = iter3->GetNextMandatoryAnimal(mandatoryAnimal);
+		assert(hasError == true);
+		assert(mandatoryAnimal != nullptr);
+		std::cout << "  Got animal: " << mandatoryAnimal->Name() << std::endl;
+		assert(std::dynamic_pointer_cast<CGiraffe>(mandatoryAnimal) != nullptr);
+		
+		hasError = iter3->GetNextMandatoryAnimal(mandatoryAnimal);
+		assert(hasError == true);
+		assert(mandatoryAnimal != nullptr);
+		std::cout << "  Got animal: " << mandatoryAnimal->Name() << std::endl;
+		assert(std::dynamic_pointer_cast<CTiger>(mandatoryAnimal) != nullptr);
+		
+		std::cout << "✓ GetNextMandatoryAnimal test passed" << std::endl;
+
+		std::cout << std::endl;
+		std::cout << "Trace 2" << std::endl;
 	}
 	catch (std::exception &e)
 	{

--- a/Source/buildimplementationcpp.go
+++ b/Source/buildimplementationcpp.go
@@ -973,7 +973,7 @@ func buildOutCacheTemplateParameters (method ComponentDefinitionMethod, NameSpac
 		
 			cppParamType := getCppParamType(param, NameSpace, true);
 			if param.ParamType == "class" || param.ParamType == "optionalclass" {
-				cppParamType = fmt.Sprintf("I%s%s*", ClassIdentifier, BaseClassName)
+				cppParamType = fmt.Sprintf("I%s%s*", ClassIdentifier, param.ParamClass)
 			}
 			result += cppParamType;
 		}


### PR DESCRIPTION
The buildOutCacheTemplateParameters function was incorrectly using BaseClassName (e.g., "Base") for ALL class output parameters when building the ParameterCache template type. This meant that methods like GeolocationList::GetAt that return specific types like IGeolocation* were being cached as IBase* instead.

When a method signature expects IGeolocation*& (reference to IGeolocation pointer) but the cache uses IBase* in its template, the compiler error occurs because: IBase*& and IGeolocation*& are incompatible types
References to pointers cannot be implicitly converted, even with inheritance